### PR TITLE
15 password encryption

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Gradle properties
-#Fri Mar 03 11:58:38 CET 2023
+#Fri Mar 03 18:24:04 CET 2023
 quarkusPluginVersion=2.16.2.Final
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPluginId=io.quarkus

--- a/librefit-service/src/main/kotlin/io/tohuwabohu/UserResource.kt
+++ b/librefit-service/src/main/kotlin/io/tohuwabohu/UserResource.kt
@@ -33,6 +33,7 @@ class UserResource(val userRepository: LibreUserRepository) {
 
         return userRepository.persistAndFlush(libreUser)
             .onItem().transform { Response.ok(libreUser).status(Response.Status.CREATED).build() }
+            .onFailure().invoke(Log::error)
             .onFailure().recoverWithItem(Response.status(Response.Status.INTERNAL_SERVER_ERROR).build())
     }
 
@@ -44,9 +45,9 @@ class UserResource(val userRepository: LibreUserRepository) {
         Log.info("Searching user with email=$email and pwd=$password")
 
         return userRepository.findByEmailAndPassword(email, password)
-            .onItem().ifNotNull().transform { user -> Response.ok(user) }
-            .onItem().ifNull().continueWith { Response.status(Response.Status.NOT_FOUND) }
-            .onFailure { true }.recoverWithItem(Response.status(Response.Status.INTERNAL_SERVER_ERROR))
-            .map { it.build() }
+            .onItem().ifNotNull().transform { user -> Response.ok(user).build() }
+            .onItem().ifNull().continueWith { Response.status(Response.Status.NOT_FOUND).build() }
+            .onFailure().invoke(Log::error)
+            .onFailure().recoverWithItem(Response.status(Response.Status.INTERNAL_SERVER_ERROR).build())
     }
 }

--- a/librefit-service/src/main/kotlin/io/tohuwabohu/crud/LibreUser.kt
+++ b/librefit-service/src/main/kotlin/io/tohuwabohu/crud/LibreUser.kt
@@ -7,7 +7,6 @@ import java.time.LocalDateTime
 import javax.enterprise.context.ApplicationScoped
 import javax.persistence.Cacheable
 import javax.persistence.Entity
-import javax.transaction.Transactional
 
 @Entity
 @Cacheable
@@ -22,5 +21,5 @@ class LibreUser: PanacheEntity() {
 @ApplicationScoped
 class LibreUserRepository : PanacheRepository<LibreUser> {
     fun findByEmailAndPassword(email: String, password: String): Uni<LibreUser?> =
-        find("email = ?1 and password = ?2", email, password).firstResult()
+        find("email = ?1 and password = crypt(?2, password)", email, password).firstResult()
 }

--- a/librefit-service/src/main/kotlin/io/tohuwabohu/crud/LibreUser.kt
+++ b/librefit-service/src/main/kotlin/io/tohuwabohu/crud/LibreUser.kt
@@ -1,5 +1,6 @@
 package io.tohuwabohu.crud
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.Uni
@@ -12,10 +13,15 @@ import javax.persistence.Entity
 @Cacheable
 class LibreUser: PanacheEntity() {
     lateinit var name: String
+    @JsonIgnore
     lateinit var password: String
     lateinit var email: String
     lateinit var registered: LocalDateTime
     var lastLogin: LocalDateTime? = null
+
+    override fun toString(): String {
+        return "LibreUser<name=$name,email=$email,registered=$registered,lastLogin=$lastLogin>"
+    }
 }
 
 @ApplicationScoped

--- a/librefit-service/src/main/resources/application.properties
+++ b/librefit-service/src/main/resources/application.properties
@@ -19,3 +19,5 @@ quarkus.smallrye-openapi.store-schema-directory=../librefit-api
 # common config
 quarkus.http.access-log.enabled=true
 quarkus.log.level=INFO
+quarkus.datasource.jdbc=false
+quarkus.datasource.reactive=true

--- a/librefit-service/src/main/resources/db/libre_user.sql
+++ b/librefit-service/src/main/resources/db/libre_user.sql
@@ -31,4 +31,4 @@ insert into libre_user (id, email, name, password, registered) values (2, 'test2
 insert into libre_user (id, email, name, password, registered) values (3, 'test3@test.dev', 'Hugh Jazz', 'test3', '2023-03-01');
 insert into libre_user (id, email, name, password, registered) values (4, 'test4@test.dev', 'Donald Duck', 'test4', '2023-03-01');
 insert into libre_user (id, email, name, password, registered) values (5, 'test5@test.dev', 'Gustav Gans', 'test5', '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (6, 'test6@test.dev', 'Gustav Gans', 'test6', '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (6, 'test6@test.dev', 'Darkwing Duck', 'test6', '2023-03-01');

--- a/librefit-service/src/main/resources/db/libre_user.sql
+++ b/librefit-service/src/main/resources/db/libre_user.sql
@@ -26,9 +26,9 @@ alter function encrypt_pwd() owner to librefit;
 
 create trigger password_trigger before insert on libre_user for each row execute procedure encrypt_pwd();
 
-insert into libre_user (id, email, name, password, registered) values (1, 'test1@test.dev', 'test1', crypt('test1', gen_salt('bf')), '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (2, 'test2@test.dev', 'Johnny Cool', crypt('test2', gen_salt('bf')), '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (3, 'test3@test.dev', 'Hugh Jazz', crypt('test3', gen_salt('bf')), '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (4, 'test4@test.dev', 'Donald Duck', crypt('test4', gen_salt('bf')), '2023-03-01');
-
+insert into libre_user (id, email, name, password, registered) values (1, 'test1@test.dev', 'test1', 'test1', '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (2, 'test2@test.dev', 'Johnny Cool', 'test2', '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (3, 'test3@test.dev', 'Hugh Jazz', 'test3', '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (4, 'test4@test.dev', 'Donald Duck', 'test4', '2023-03-01');
 insert into libre_user (id, email, name, password, registered) values (5, 'test5@test.dev', 'Gustav Gans', 'test5', '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (6, 'test6@test.dev', 'Gustav Gans', 'test6', '2023-03-01');

--- a/librefit-service/src/main/resources/db/libre_user.sql
+++ b/librefit-service/src/main/resources/db/libre_user.sql
@@ -1,3 +1,5 @@
+create extension pgcrypto;
+
 create table libre_user
 (
     id         bigint not null
@@ -12,7 +14,21 @@ create table libre_user
 alter table libre_user
     owner to librefit;
 
-insert into libre_user (id, email, name, password, registered) values (1, 'test1@test.dev', 'test1', 'test1', '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (2, 'test2@test.dev', 'Johnny Cool', 'test2', '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (3, 'test3@test.dev', 'Hugh Jazz', 'test3', '2023-03-01');
-insert into libre_user (id, email, name, password, registered) values (4, 'test4@test.dev', 'Donald Duck', 'test4', '2023-03-01');
+create function encrypt_pwd()
+    returns trigger AS $$
+begin
+    NEW.password := crypt(NEW.password, gen_salt('bf'));
+    return NEW;
+end;
+$$ language plpgsql;
+
+alter function encrypt_pwd() owner to librefit;
+
+create trigger password_trigger before insert on libre_user for each row execute procedure encrypt_pwd();
+
+insert into libre_user (id, email, name, password, registered) values (1, 'test1@test.dev', 'test1', crypt('test1', gen_salt('bf')), '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (2, 'test2@test.dev', 'Johnny Cool', crypt('test2', gen_salt('bf')), '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (3, 'test3@test.dev', 'Hugh Jazz', crypt('test3', gen_salt('bf')), '2023-03-01');
+insert into libre_user (id, email, name, password, registered) values (4, 'test4@test.dev', 'Donald Duck', crypt('test4', gen_salt('bf')), '2023-03-01');
+
+insert into libre_user (id, email, name, password, registered) values (5, 'test5@test.dev', 'Gustav Gans', 'test5', '2023-03-01');


### PR DESCRIPTION
- encryption moved to database layer
- remove password field from json respone
- increase error verbosity

I'm not happy with the solution, the quarkus-security-jpa extension relies on JDBC instead of vert.x and thus was rendered incompatible. So, instead of an annotation, the password is encrypted with a salted hash based on blowfish encryption from the pgcrypto extension, triggered on any new INSERT statement (yes with a database trigger function).
On the positive side, moving encryption from the application layer allows to easily create test data with SQL instead of an ORM creation script.